### PR TITLE
include render troubleshooting in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The container component is the map, and there are a variety of components which 
   accessToken="<your api key>" // add your api key here
   bind:this={mapComponent} // Get reference to your map component to use methods
   on:recentre={e => console.log(e.detail.center.lat, e.detail.center.lng) } // recentre events
+  options={{ scrollZoom: false }} // // add arbitrary options to the map from the mapbox api
 >
   <Earthquakes /> // Any custom component you create or want here - see marker example
   <Marker lat={someLat} lng={someLng} color="rgb(255,255,255)" label="some marker label" popupClassName="class-name" /> // built in Marker component

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ The container component is the map, and there are a variety of components which 
     // do something with `data`, it's the result returned from the mapbox event
   }
 </script>
+
+<style>
+    .mapboxgl-map {
+        height: 200px;
+	// sometimes mapbox objects don't render as expected; troubleshoot by changing the height/width to px
+    }
+</style>
 ```
 ## Basic Usage (Geocoder)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The container component is the map, and there are a variety of components which 
 <style>
     :global(.mapboxgl-map) {
         height: 200px;
-	// sometimes mapbox objects don't render as expected; troubleshoot by changing the height/width to px
+        // sometimes mapbox objects don't render as expected; troubleshoot by changing the height/width to px
     }
 </style>
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The container component is the map, and there are a variety of components which 
 </script>
 
 <style>
-    .mapboxgl-map {
+    :global(.mapboxgl-map) {
         height: 200px;
 	// sometimes mapbox objects don't render as expected; troubleshoot by changing the height/width to px
     }


### PR DESCRIPTION
Added example of troubleshooting map render. Additionally, I considered adding an example of options on the base map as I didn't even notice there was already an example on GeolocateControl:  

```jsx
<GeolocateControl options={{ some: 'control-option' }} on:eventname={eventHandler} />
```

It would look something like:
```jsx
<Map
  accessToken="<your api key>" // add your api key here
  bind:this={mapComponent} // Get reference to your map component to use methods
  on:recentre={e => console.log(e.detail.center.lat, e.detail.center.lng) } // recentre events
  options={{ scrollZoom: false }} // add arbitrary options to the map
>
```

Let me know if you think it's redundant; I'll note I think I didn't notice the existing example on GeolocateControl because I knew I just wanted to get a basic example working and didn't want geolocation.