### PR TITLE
Geocoder component: Export localGeocoder option

### DIFF
--- a/src/Geocoder.svelte
+++ b/src/Geocoder.svelte
@@ -13,6 +13,7 @@
   export let version = 'v4.5.1'
   export let types = [ 'country', 'region', 'postcode', 'district', 'place', 'locality', 'neighborhood', 'address' ]
   export let placeholder = 'Search'
+  export let localGeocoder = null
   export let value = null
 
   export let geocoder = null
@@ -49,7 +50,8 @@
     const optionsWithDefaults = Object.assign({
       accessToken,
       types: types.join(','),
-      placeholder
+      placeholder,
+      localGeocoder
     }, options)
     geocoder = new window.MapboxGeocoder(optionsWithDefaults)
     geocoder.addTo(`#${fieldId}`)


### PR DESCRIPTION
- Add the `localGeocoder` option in the Geocoder constructor and export it.

Was able to test and implement this example https://docs.mapbox.com/mapbox-gl-js/example/forward-geocode-custom-data/

<img width="678" alt="Screen Shot 2020-11-29 at 3 51 37 PM" src="https://user-images.githubusercontent.com/126868/100553244-d5c78400-325a-11eb-8e9e-172f87834078.png">


Closes #21