### PR TITLE
Custom Markers as slot

### DIFF
--- a/src/Marker.svelte
+++ b/src/Marker.svelte
@@ -25,11 +25,16 @@
   export let popup = true
 
   let marker
+  let element
 
   $: marker && move(lng, lat)
 
   onMount(() => {
-    marker = new mapbox.Marker({ color, offset: markerOffset })
+    if(element.hasChildNodes()) {
+      marker = new mapbox.Marker({ element, offset: markerOffset })
+    } else {
+      marker = new mapbox.Marker({ color, offset: markerOffset })
+    }
 
     if (popup) {
       const popupEl = new mapbox.Popup({
@@ -51,3 +56,7 @@
     return marker
   }
 </script>
+
+<div bind:this={element}>
+<slot ></slot>
+</div>


### PR DESCRIPTION
This adds the ability to user HTML inside the Marker which gets used as marker:

```svelte
<Marker
    popup={false}
    lat={geo.lat}
    lng={geo.lng}
    >
    <a href={target.link}>
        <p>{target.title}</p>
    </a>
</Marker>
```

Default behavior is still preserved.

Will fix https://github.com/beyonk-adventures/svelte-mapbox/issues/33