### PR TITLE
Add named Slot for Popup html

### DIFF
--- a/src/Marker.svelte
+++ b/src/Marker.svelte
@@ -63,7 +63,7 @@
   }
 </script>
 
-<div bind:this={element} class='mapMarker'>
+<div bind:this={element}>
 <slot ></slot>
 </div>
 

--- a/src/Marker.svelte
+++ b/src/Marker.svelte
@@ -43,7 +43,7 @@
         className: popupClassName
       });
       if (elementPopup.hasChildNodes()) {
-        popupEl.setHTML(elementPopup.innerHTML)
+        popupEl.setDOMContent(elementPopup)
       } else {
         popupEl.setText(label);
       }
@@ -70,9 +70,3 @@
 <div class='popup' bind:this={elementPopup}>
   <slot name="popup"></slot>
 </div>
-
-<style>
-  .popup {
-    display:none;
-  }
-</style>

--- a/src/Marker.svelte
+++ b/src/Marker.svelte
@@ -2,7 +2,6 @@
   import { onMount } from 'svelte'
   import { getContext } from 'svelte'
   import { contextKey } from './mapbox.js'
-  import { afterUpdate, beforeUpdate } from 'svelte';
 
   const { getMap, getMapbox } = getContext(contextKey)
   const map = getMap()
@@ -73,12 +72,6 @@
 </div>
 
 <style>
-  .mapMarker {
-    z-index: 1;
-  }
-  .mapMarker:hover {
-    z-index: 2;
-  }
   .popup {
     display:none;
   }

--- a/src/Marker.svelte
+++ b/src/Marker.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte'
   import { getContext } from 'svelte'
   import { contextKey } from './mapbox.js'
+  import { afterUpdate, beforeUpdate } from 'svelte';
 
   const { getMap, getMapbox } = getContext(contextKey)
   const map = getMap()
@@ -23,9 +24,10 @@
   export let popupOffset = 10
   export let color = randomColour()
   export let popup = true
-
+  
   let marker
   let element
+  let elementPopup
 
   $: marker && move(lng, lat)
 
@@ -35,12 +37,17 @@
     } else {
       marker = new mapbox.Marker({ color, offset: markerOffset })
     }
-
+    
     if (popup) {
       const popupEl = new mapbox.Popup({
         offset: popupOffset,
         className: popupClassName
-      }).setText(label)
+      });
+      if (elementPopup.hasChildNodes()) {
+        popupEl.setHTML(elementPopup.innerHTML)
+      } else {
+        popupEl.setText(label);
+      }
 
       marker.setPopup(popupEl)
     }
@@ -57,6 +64,22 @@
   }
 </script>
 
-<div bind:this={element}>
+<div bind:this={element} class='mapMarker'>
 <slot ></slot>
 </div>
+
+<div class='popup' bind:this={elementPopup}>
+  <slot name="popup"></slot>
+</div>
+
+<style>
+  .mapMarker {
+    z-index: 1;
+  }
+  .mapMarker:hover {
+    z-index: 2;
+  }
+  .popup {
+    display:none;
+  }
+</style>


### PR DESCRIPTION
This adds up on https://github.com/beyonk-adventures/svelte-mapbox/pull/34 and adds the functionality of https://github.com/beyonk-adventures/svelte-mapbox/pull/26 per named slot.

Should enable to use

```svelte
<Marker
   popup={true}
   lat={waypoint.geo.lat}
   lng={waypoint.geo.lng}
   > 

      <a href={waypoint.slug}>
         <p>MyMarker HTML</p>
       </a>

      <span slot="popup">
         <p>My Popup HTML</p>
      </span>

</Marker>
```

as well as
```svelte
<Marker
   popup={true}
   lat={waypoint.geo.lat}
   lng={waypoint.geo.lng}
   > 

      <span slot="popup">
         <p>My Popup HTML</p>
      </span>

</Marker>
```

as well as the default behaviour with label as marker text.