### PR TITLE
Update Map.svelte

### DIFF
--- a/src/lib/map/Map.svelte
+++ b/src/lib/map/Map.svelte
@@ -8,6 +8,7 @@
   on:zoom
   on:zoomend
   on:drag
+  on:keydown
   >
   {#if map}
   <slot></slot>


### PR DESCRIPTION
A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.