### PR TITLE
Fix race condition in asset loader when script tag hasn't loaded

### DIFF
--- a/src/lib/asset-loader.js
+++ b/src/lib/asset-loader.js
@@ -4,7 +4,11 @@ function load (assets, cb) {
 
     if (existing) {
       if (type === 'script') {
-        cb()
+        if (window.mapboxgl) {
+          cb()
+        } else {
+          existing.addEventListener('load', () => cb(), { once: true })
+        }
       }
       return
     }


### PR DESCRIPTION
When multiple components mount simultaneously, the script tag may already exist in the DOM but mapboxgl hasn't finished loading yet. The loader would call cb() immediately, causing TypeError when trying to set accessToken on undefined.

Now checks if window.mapboxgl is available. If not, waits for the existing script's load event before calling the callback.